### PR TITLE
Add kbcc_converter (Currency & Crypto Converter)

### DIFF
--- a/library-of-plugins/kbcc_converter.json
+++ b/library-of-plugins/kbcc_converter.json
@@ -1,0 +1,20 @@
+{
+  "name": "kbcc_converter",
+  "repositories": [
+    {
+      "repoType": "github",
+      "repoUrl": "https://github.com/linkforceio/textpattern-kbcc-converter"
+    },
+    {
+      "repoType": "homepage",
+      "repoUrl": "https://kryptoboersen.net"
+    }
+  ],
+  "stable": {
+    "version": "1.0.0",
+    "datePublished": "2026-07-12",
+    "downloadUrlPhp": "https://github.com/linkforceio/textpattern-kbcc-converter/archive/refs/tags/v1.0.0.zip",
+    "phpHasManifest": 1,
+    "downloadUrlTxt": "https://github.com/linkforceio/textpattern-kbcc-converter/releases/download/v1.0.0/kbcc_converter_v1.0.0.txt"
+  }
+}


### PR DESCRIPTION
Adds `kbcc_converter` (Currency & Crypto Converter): a tag `<txp:kbcc_converter />` that renders a self-contained converter for major currencies (EUR, USD, GBP, CHF) and cryptocurrencies (BTC, ETH, USDC) with live rates. MIT licensed, manifest included, stable v1.0.0 with both .txt and .php downloads on GitHub Releases.